### PR TITLE
Added drmaa and couchdb as a dependency for the pipeline

### DIFF
--- a/nextgen/setup.py
+++ b/nextgen/setup.py
@@ -47,6 +47,8 @@ setup(name="bcbio-nextgen",
           "celery == 2.5",
           "nose >= 1.0.0",
           "gdata >= 2.0.14",
+          "drmaa >= 0.5",
+          "couchdb >= 0.8",
           "BeautifulSoup4"
       ])
 


### PR DESCRIPTION
Hi,

I think that this dependences should be added to the modules installed with the pipeline
- couchdb is used in the standard tests of the pipeline, so It has sense that is installed with the pipeline.
- drmaa is used when running the recipe I'm working on at the moment of running the test suite in UPPMAX

What do you think? 

Tack!
