### PR TITLE
Picard issues with the pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     - sudo add-apt-repository -y ppa:scilifelab/scilifelab
     - sudo add-apt-repository -y ppa:debian-med/ppa
     - sudo apt-get update
-    - sudo apt-get install -q -y git-core gcc picard-tools=1.74-1ubuntu1 bowtie bwa freebayes snpeff-2 fastqc-0.10.1 gatk r-base tophat openjdk-6-jre samtools unzip lftp cufflinks wigtools
+    - sudo apt-get install -q -y git-core gcc libsam-java=1.74-1ubuntu1 picard-tools=1.74-1ubuntu1 bowtie bwa freebayes snpeff-2 fastqc-0.10.1 gatk r-base tophat openjdk-6-jre samtools unzip lftp cufflinks wigtools
     #Download snpeff gnome database
     - lftp -e 'pget -n 8 http://downloads.sourceforge.net/project/snpeff/databases/v2_0_5/snpEff_v2_0_5_GRCh37.63.zip; quit'
     - sudo unzip snpEff_v2_0_5_GRCh37.63.zip -d /usr/share/snpEff/ && rm snpEff_v2_0_5_GRCh37.63.zip


### PR DESCRIPTION
Debian-med team has packaged the new version of picard-tools, which is not compatible with our pipeline when installing "normally". Our pipeline needs all individual .jar files, which are not installed in the normal way (a single picard-tools wrapper script is installed). As debian-med version is higher than ours, and we're using their repository to download other dependencies, apt is getting their picard-tools version. 

I've pointed to our specific version of picard-tools by the moment, but maybe we can take a look at this fact.

As @chapmanb is making a few changes in the pipeline now, maybe he can advise us with this matter? 

Thank you very much!
