### PR TITLE
Invalid cross-device link solved by substituting os.rename by shutil.move

### DIFF
--- a/nextgen/bcbio/utils.py
+++ b/nextgen/bcbio/utils.py
@@ -397,7 +397,7 @@ def merge_demux_results(fc_dir):
                     m_demultiplex_stats.renderContents()))
     else:
         #There is only one Unaligned folder, but it is named Unaligned_Xbp
-        os.rename(unaligned_dirs[0], 'Unaligned')
+        shutil.move(unaligned_dirs[0], 'Unaligned')
 
 
 # UTF-8 methods for csv module (does not support it in python >2.7)


### PR DESCRIPTION
I've encountered these messages in the logs:

```
  File "/home/hiseq.bioinfo/.virtualenvs/master/lib/python2.7/site-packages/bcbio_nextgen-1.0_82_g2756ba6-py2.7.egg/bcbio/utils.py", line 400, in merge_demux_results
    os.rename(unaligned_dirs[0], 'Unaligned')
OSError: [Errno 18] Invalid cross-device link
```

According to several threads (just google for "os.rename Invalid cross-device link"), os.rename may have problems in mounted/shared partitions, which I didn't realized because I was testing locally.
