### PR TITLE
Synch demultiplexing results to MooseFS

### DIFF
--- a/nextgen/scripts/illumina_finished_msg.py
+++ b/nextgen/scripts/illumina_finished_msg.py
@@ -214,7 +214,7 @@ def process_second_read(*args, **kwargs):
                       "--progress", \
                       "--prune-empty-dirs", \
                       os.path.join(dname, 'Unaligned'), \
-                      os.path.join(config.has_key('mfs_dir'), dname)
+                      os.path.join(config.get('mfs_dir'), dname)
                       ]
                 logger2.info("Synching Unaligned folder to MooseFS")
                 logdir = os.path.join(config.get('log_dir'), os.getcwd())


### PR DESCRIPTION
See [trello card](https://trello.com/c/tKF6uD5z/269-sync-demultiplexing-results-to-location-visible-by-lims) for a detailed description.
