### PR TITLE
Single read sequenced

### DIFF
--- a/nextgen/scripts/illumina_finished_msg.py
+++ b/nextgen/scripts/illumina_finished_msg.py
@@ -595,8 +595,8 @@ def _generate_fastq_with_casava_task(args):
             ce.close()
         
         #Move R2 (and R3) fastq files to Undetermined_idices. And rename second read to R2
-        if not r1 and bp == 0:
-            indices = [int(read.get("Number")) for read in _get_read_configuration(fc_dir) if read.get("IsIndexedRead","") == "Y"]
+        indices = [int(read.get("Number")) for read in _get_read_configuration(fc_dir) if read.get("IsIndexedRead","") == "Y"]
+        if not r1 and bp == 0 and bool(indices):
             sample_glob = os.path.join(unaligned_dir, "Project*","Sample*")
             sample_dirs = glob.glob(sample_glob)
 


### PR DESCRIPTION
I made a mistake. If the sequencer was not configured to run index cycles even if there (hopefully) are none on the templates, the code will crash. 

It should now function as before, only that the fastq files are found in fc_dir/Unaligned_0bp
