### PR TITLE
Easy PR!! Hot fix!!

### DIFF
--- a/nextgen/bcbio/pipeline/qcsummary.py
+++ b/nextgen/bcbio/pipeline/qcsummary.py
@@ -242,7 +242,7 @@ def _run_fastqc(bam_file, config):
                               os.path.splitext(os.path.basename(bam_file))[0])
     if not os.path.exists(fastqc_out):
         cl = [config.get("program", {}).get("fastqc", "fastqc"),
-              "-o", out_base, "-f", "bam", bam_file]
+              "--extract", "-o", out_base, "-f", "bam", bam_file]
         subprocess.check_call(cl)
 
     if os.path.exists("%s.zip" % fastqc_out):


### PR DESCRIPTION
We updated fastqc in our pipeline (basically using new version), and it seems like the pipeline doesn't automatically extract the zipped fastqc report as previous version. So explicitly asking to extract it.  
