### PR TITLE
HOT FIX: new fastq_screen!!

### DIFF
--- a/nextgen/bcbio/pipeline/qcsummary.py
+++ b/nextgen/bcbio/pipeline/qcsummary.py
@@ -259,8 +259,7 @@ def _run_fastq_screen(fastq1, fastq2, config):
     utils.safe_makedir(out_base)
     program = config.get("program", {}).get("fastq_screen", "fastq_screen")
 
-    cl = [program, "--outdir", out_base, "--subset", "2000000", \
-        "--multilib", fastq1]
+    cl = [program, "--outdir", out_base, "--subset", "2000000", fastq1]
 
     if config["algorithm"].get("quality_format", "").lower() == 'illumina':
         cl.insert(1, "--illumina")


### PR DESCRIPTION
Old fastq_screen broke cause of uppmax issue, now using new version which don't have the removed "parameter". Hopefully they should have made it as default. This change should not affect anything, maybe maya's script that checks and grep from fastq_screen output. In case if that got changed because of this, its better to fix that script.

P.S: small fix, so self merging :+1: 
